### PR TITLE
[TASK] Vuetify3の導入 #10

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,12 +1,39 @@
+import vuetify, { transformAssetUrls } from 'vite-plugin-vuetify';
+
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
   compatibilityDate: '2024-11-01',
   devtools: { enabled: true },
-  modules: ['@nuxt/eslint'],
+  build: {
+    transpile: ['vuetify'],
+  },
+  plugins: [
+    '~/plugins/vuetify.ts',
+  ],
+  modules: ['@nuxt/eslint',
+    (_options, nuxt): void => {
+      nuxt.hooks.hook('vite:extendConfig', (config) => {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-expect-error
+        config.plugins.push(vuetify({ autoImport: true }));
+      });
+    },
+  ],
   eslint: {
     config: {
       stylistic: true,
     },
   },
+  vite: {
+    vue: {
+      template: {
+        transformAssetUrls,
+      },
+    },
+  },
+  css: [
+    'vuetify/lib/styles/main.sass',
+    '@mdi/font/css/materialdesignicons.css',
+  ],
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,14 +7,18 @@
       "name": "nuxt-app",
       "hasInstallScript": true,
       "dependencies": {
+        "@mdi/font": "^7.4.47",
         "@nuxt/eslint": "^0.7.5",
         "eslint": "^9.18.0",
         "nuxt": "^3.15.1",
+        "sass": "^1.83.4",
         "vue": "latest",
         "vue-router": "latest"
       },
       "devDependencies": {
-        "@typescript-eslint/eslint-plugin": "^8.20.0"
+        "@typescript-eslint/eslint-plugin": "^8.20.0",
+        "vite-plugin-vuetify": "^2.0.4",
+        "vuetify": "^3.7.6"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1594,6 +1598,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@mdi/font": {
+      "version": "7.4.47",
+      "resolved": "https://registry.npmjs.org/@mdi/font/-/font-7.4.47.tgz",
+      "integrity": "sha512-43MtGpd585SNzHZPcYowu/84Vz2a2g31TvPMTm9uTiCSWzaheQySUcSyUH/46fPnuPQWof2yd0pGBtzee/IQWw==",
+      "license": "Apache-2.0"
     },
     "node_modules/@netlify/functions": {
       "version": "2.8.2",
@@ -3516,6 +3526,20 @@
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.13.tgz",
       "integrity": "sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ==",
       "license": "MIT"
+    },
+    "node_modules/@vuetify/loader-shared": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@vuetify/loader-shared/-/loader-shared-2.0.3.tgz",
+      "integrity": "sha512-Ss3GC7eJYkp2SF6xVzsT7FAruEmdihmn4OCk2+UocREerlXKWgOKKzTN5PN3ZVN5q05jHHrsNhTuWbhN61Bpdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "upath": "^2.0.1"
+      },
+      "peerDependencies": {
+        "vue": "^3.0.0",
+        "vuetify": "^3.0.0"
+      }
     },
     "node_modules/abbrev": {
       "version": "2.0.0",
@@ -6563,6 +6587,12 @@
       "integrity": "sha512-K6acvFaelNxx8wc2VjbIzXKDVB0Khs0QT35U6NkGfTdCmjLNcO2945m7RFNR9/RPVFm48hq7QPzK8uGH18HCGw==",
       "license": "MIT"
     },
+    "node_modules/immutable": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.0.3.tgz",
+      "integrity": "sha512-P8IdPQHq3lA1xVeBRi5VPqUm5HDgKnx0Ru51wZz5mjxHr5n3RWhjIpOFU7ybkUxfB+5IToy+OLaHYDBIWsv+uw==",
+      "license": "MIT"
+    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -9576,6 +9606,26 @@
       ],
       "license": "MIT"
     },
+    "node_modules/sass": {
+      "version": "1.83.4",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.83.4.tgz",
+      "integrity": "sha512-B1bozCeNQiOgDcLd33e2Cs2U60wZwjUUXzh900ZyQF5qUasvMdDZYbQ566LJu7cqR+sAHlAfO6RMkaID5s6qpA==",
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^4.0.0",
+        "immutable": "^5.0.2",
+        "source-map-js": ">=0.6.2 <2.0.0"
+      },
+      "bin": {
+        "sass": "sass.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher": "^2.4.1"
+      }
+    },
     "node_modules/scslre": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/scslre/-/scslre-0.3.0.tgz",
@@ -10839,6 +10889,17 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/upath": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/upath/-/upath-2.0.1.tgz",
+      "integrity": "sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4",
+        "yarn": "*"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.2.tgz",
@@ -11714,6 +11775,26 @@
         "vite": "^3.0.0-0 || ^4.0.0-0 || ^5.0.0-0 || ^6.0.0-0"
       }
     },
+    "node_modules/vite-plugin-vuetify": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/vite-plugin-vuetify/-/vite-plugin-vuetify-2.0.4.tgz",
+      "integrity": "sha512-A4cliYUoP/u4AWSRVRvAPKgpgR987Pss7LpFa7s1GvOe8WjgDq92Rt3eVXrvgxGCWvZsPKziVqfHHdCMqeDhfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vuetify/loader-shared": "^2.0.3",
+        "debug": "^4.3.3",
+        "upath": "^2.0.1"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "vite": ">=5",
+        "vue": "^3.0.0",
+        "vuetify": "^3.0.0"
+      }
+    },
     "node_modules/vscode-jsonrpc": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
@@ -11895,6 +11976,37 @@
       },
       "peerDependencies": {
         "vue": "^3.2.0"
+      }
+    },
+    "node_modules/vuetify": {
+      "version": "3.7.6",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.7.6.tgz",
+      "integrity": "sha512-lol0Va5HtMIqZfjccSD5DLv5v31R/asJXzc6s7ULy51PHr1DjXxWylZejhq0kVpMGW64MiV1FmA/p8eYQfOWfQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20 || >=14.13"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/johnleider"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.7",
+        "vite-plugin-vuetify": ">=1.0.0",
+        "vue": "^3.3.0",
+        "webpack-plugin-vuetify": ">=2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "vite-plugin-vuetify": {
+          "optional": true
+        },
+        "webpack-plugin-vuetify": {
+          "optional": true
+        }
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -12,13 +12,17 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
+    "@mdi/font": "^7.4.47",
     "@nuxt/eslint": "^0.7.5",
     "eslint": "^9.18.0",
     "nuxt": "^3.15.1",
+    "sass": "^1.83.4",
     "vue": "latest",
     "vue-router": "latest"
   },
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^8.20.0"
+    "@typescript-eslint/eslint-plugin": "^8.20.0",
+    "vite-plugin-vuetify": "^2.0.4",
+    "vuetify": "^3.7.6"
   }
 }

--- a/plugins/vuetify.ts
+++ b/plugins/vuetify.ts
@@ -1,0 +1,5 @@
+import vuetify from '../utils/vuetify';
+
+export default defineNuxtPlugin((nuxtApp) => {
+  nuxtApp.vueApp.use(vuetify);
+});

--- a/utils/vuetify.ts
+++ b/utils/vuetify.ts
@@ -1,0 +1,13 @@
+import '@mdi/font/css/materialdesignicons.css';
+import 'vuetify/styles';
+import { createVuetify } from 'vuetify';
+import * as components from 'vuetify/components';
+import * as directives from 'vuetify/directives';
+
+export default createVuetify({
+  components,
+  directives,
+  theme: {
+    defaultTheme: 'light',
+  },
+});


### PR DESCRIPTION
# [TASK] Vuetify3の導入 #10

## 概要
Vuetifyの導入

## 変更内容
- Vuetifyのセットアップ用の新しいプラグインを含め、VuetifyをNuxtのコンフィギュレーションに統合しました。
- Nuxtの設定を更新し、Vuetifyに必要なビルドとViteの設定を含めました。
- Vuetifyとその関連プラグインの新しい依存関係を `package.json` と `package-lock.json` に追加した。
- コンポーネントとディレクティブのインポートを効率化するために、Vuetifyの設定のための新しいユーティリティファイルを導入しました。
- Vuetify と関連パッケージの最新バージョンとの互換性を確保した。

## 関連するIssue
#10 

## チェックリスト
- [ ] コードが正しく動作することを確認しました
- [ ] テストを追加/更新しました
- [ ] ドキュメントを更新しました

## その他
プロジェクトにおける細かい設定はせず、初期状態のまま導入
