### PR TITLE
Vuetifyの設定にデザイン色を設定する

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,20 +1,20 @@
 // @ts-check
-import withNuxt from './.nuxt/eslint.config.mjs';
+import withNuxt from './.nuxt/eslint.config.mjs'
 
 export default withNuxt([
   {
     rules: {
-      'no-console': 'warn',                    // console.logの使用を警告
-      'no-unused-vars': 'error',               // 未使用の変数をエラーとして報告
-      'eqeqeq': 'error',                       // 厳密等価演算子（===）の使用を強制
-      'curly': 'error',                        // すべての制御文に波括弧を強制
-      'semi': ['error', 'always'],             // セミコロンの使用を強制
-      'quotes': ['error', 'single'],           // シングルクォートの使用を強制
-      'no-trailing-spaces': 'error',           // 行末の空白を禁止
-      'indent': ['error', 2],                  // インデント2スペース
+      'no-console': 'warn', // console.logの使用を警告
+      'no-unused-vars': 'error', // 未使用の変数をエラーとして報告
+      'eqeqeq': 'error', // 厳密等価演算子（===）の使用を強制
+      'curly': 'error', // すべての制御文に波括弧を強制
+      'stylistic/semi': 'off', // stylistic/semiルールを無効化
+      'quotes': ['error', 'single'], // シングルクォートの使用を強制
+      'no-trailing-spaces': 'error', // 行末の空白を禁止
+      'indent': ['error', 2], // インデント2スペース
       'comma-dangle': ['error', 'always-multiline'], // 複数行の場合は末尾カンマを強制
-      'no-var': 'error',                       // varの使用を禁止
-      'prefer-const': 'error',                 // 再代入がない場合はconstを強制
+      'no-var': 'error', // varの使用を禁止
+      'prefer-const': 'error', // 再代入がない場合はconstを強制
     },
     languageOptions: {
       globals: {
@@ -29,24 +29,24 @@ export default withNuxt([
   {
     files: ['**/*.vue'],
     rules: {
-      'vue/require-v-for-key': 'error',        // v-forディレクティブでkeyの指定を強制
-      'vue/no-use-v-if-with-v-for': 'error',   // v-ifとv-forの同時使用を禁止
+      'vue/require-v-for-key': 'error', // v-forディレクティブでkeyの指定を強制
+      'vue/no-use-v-if-with-v-for': 'error', // v-ifとv-forの同時使用を禁止
       'vue/multi-word-component-names': 'error', // コンポーネント名は複数単語を強制
-      'vue/html-indent': ['error', 2],         // テンプレートのインデントを2スペースに
+      'vue/html-indent': ['error', 2], // テンプレートのインデントを2スペースに
       'vue/html-closing-bracket-newline': ['error', {
-        'singleline': 'never',                 // 単一行の場合は改行なし
-        'multiline': 'always',                  // 複数行の場合は改行を強制
+        singleline: 'never', // 単一行の場合は改行なし
+        multiline: 'always', // 複数行の場合は改行を強制
       }],
     },
   },
   {
     files: ['**/*.vue', '**/*.ts'],
     rules: {
-      'no-console': 'error',                   // 本番環境ではconsole.logを禁止
-      '@typescript-eslint/no-explicit-any': 'error',           // any型の使用を禁止
+      'no-console': 'error', // 本番環境ではconsole.logを禁止
+      '@typescript-eslint/no-explicit-any': 'error', // any型の使用を禁止
       '@typescript-eslint/explicit-function-return-type': 'error', // 関数の戻り値の型を明示的に指定
-      '@typescript-eslint/no-unused-vars': 'error',            // 未使用の変数をエラーとして報告
+      '@typescript-eslint/no-unused-vars': 'error', // 未使用の変数をエラーとして報告
       '@typescript-eslint/consistent-type-definitions': ['error', 'interface'], // 型定義に一貫性を強制
     },
   },
-]);
+])

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,29 +1,28 @@
-import vuetify, { transformAssetUrls } from 'vite-plugin-vuetify';
+import vuetify, { transformAssetUrls } from 'vite-plugin-vuetify'
 
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
-  compatibilityDate: '2024-11-01',
-  devtools: { enabled: true },
-  build: {
-    transpile: ['vuetify'],
-  },
-  plugins: [
-    '~/plugins/vuetify.ts',
-  ],
   modules: ['@nuxt/eslint',
     (_options, nuxt): void => {
       nuxt.hooks.hook('vite:extendConfig', (config) => {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-expect-error
-        config.plugins.push(vuetify({ autoImport: true }));
-      });
+        config.plugins.push(vuetify({ autoImport: true }))
+      })
     },
   ],
-  eslint: {
-    config: {
-      stylistic: true,
-    },
+  plugins: [
+    '~/plugins/vuetify.ts',
+  ],
+  devtools: { enabled: true },
+  css: [
+    'vuetify/lib/styles/main.sass',
+    '@mdi/font/css/materialdesignicons.css',
+  ],
+  build: {
+    transpile: ['vuetify'],
   },
+  compatibilityDate: '2024-11-01',
   vite: {
     vue: {
       template: {
@@ -31,9 +30,9 @@ export default defineNuxtConfig({
       },
     },
   },
-  css: [
-    'vuetify/lib/styles/main.sass',
-    '@mdi/font/css/materialdesignicons.css',
-  ],
-});
-
+  eslint: {
+    config: {
+      stylistic: true,
+    },
+  },
+})

--- a/plugins/vuetify.ts
+++ b/plugins/vuetify.ts
@@ -1,5 +1,5 @@
-import vuetify from '../utils/vuetify';
+import vuetify from '../utils/vuetify'
 
 export default defineNuxtPlugin((nuxtApp) => {
-  nuxtApp.vueApp.use(vuetify);
-});
+  nuxtApp.vueApp.use(vuetify)
+})

--- a/utils/vuetify.ts
+++ b/utils/vuetify.ts
@@ -1,13 +1,33 @@
-import '@mdi/font/css/materialdesignicons.css';
-import 'vuetify/styles';
-import { createVuetify } from 'vuetify';
-import * as components from 'vuetify/components';
-import * as directives from 'vuetify/directives';
+import '@mdi/font/css/materialdesignicons.css'
+import 'vuetify/styles'
+import { createVuetify } from 'vuetify'
+import * as components from 'vuetify/components'
+import * as directives from 'vuetify/directives'
 
 export default createVuetify({
   components,
   directives,
   theme: {
     defaultTheme: 'light',
+    themes: {
+      light: {
+        dark: false,
+        colors: {
+          'primary': '#f49340', // オレンジ
+          'secondary': '#373735', // ダークグレー
+          'background': '#eae8e1', // ライトベージュ
+          'accent': '#fbdcaf', // ライトオレンジ
+
+          // Vuetifyのデフォルトカラーも設定
+          'surface': '#eae8e1',
+          'surface-variant': '#fbdcaf',
+          'on-surface-variant': '#373735',
+          'error': '#B00020',
+          'info': '#2196F3',
+          'success': '#4CAF50',
+          'warning': '#FB8C00',
+        },
+      },
+    },
   },
-});
+})


### PR DESCRIPTION
# Vuetifyの設定にデザイン色を設定する

## 概要

- ESLintのルールを更新し、文体の調整や文体のセミルールを無効にする新しいルールの追加など、コードの品質を向上させました。
- Vuetifyテーマ設定の追加を含め、プラグインのインポートを合理化し、適切な構造を確保することにより、Nuxt設定を洗練させました。
- Vuetifyユーティリティファイルを強化し、UIの一貫性を向上させるために、特定のカラー設定を持つカスタムライトテーマを定義できるようにしました。
- 不要なセミコロンを削除し、適切な書式を確保することで、すべてのインポートが最新のコーディング標準と一貫していることを確認しました。


## 変更内容
デザイン案の色をVuetifyで呼び出せるように修正

https://zenn.dev/link/comments/f4bd9c4a12d1c1

## 関連するIssue
#14 

## チェックリスト
- [ ] コードが正しく動作することを確認しました
- [ ] テストを追加/更新しました
- [ ] ドキュメントを更新しました

## その他
エディタか何かの制約とバッティングしたのでセミコロン必須を削除しました


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- Vuetifyテーマの詳細なカスタマイズを追加
	- 新しいライトテーマカラーパレットを導入

- **スタイル**
	- ESLintの設定を微調整
	- コードフォーマットを最適化

- **その他の変更**
	- プラグインとコンフィグレーションファイルの小規模な構造調整

<!-- end of auto-generated comment: release notes by coderabbit.ai -->