### PR TITLE
アイコンのサポート追加によるVuetify設定の強化

### DIFF
--- a/utils/vuetify.ts
+++ b/utils/vuetify.ts
@@ -1,12 +1,21 @@
 import '@mdi/font/css/materialdesignicons.css'
 import 'vuetify/styles'
 import { createVuetify } from 'vuetify'
+import { aliases, mdi } from 'vuetify/iconsets/mdi'
 import * as components from 'vuetify/components'
 import * as directives from 'vuetify/directives'
 
-export default createVuetify({
+const vuetify: ReturnType<typeof createVuetify> = createVuetify({
   components,
   directives,
+  icons: {
+    defaultSet: 'mdi',
+    aliases,
+    sets: {
+      mdi,
+    },
+  },
+
   theme: {
     defaultTheme: 'light',
     themes: {
@@ -31,3 +40,5 @@ export default createVuetify({
     },
   },
 })
+
+export default vuetify


### PR DESCRIPTION
# アイコンのサポート追加によるVuetify設定の強化

## 概要
このコミットは、Vuetifyのセットアップでマテリアルデザインのアイコンを使用できるようにすることで、UIコンポーネントのエクスペリエンスを改善します。

## 変更内容
- VuetifyユーティリティファイルにMDIアイコンセットのサポートを導入。
- アイコンの管理を改善するために、デフォルトのアイコンセットとエイリアスを設定しました。
- アイコンの適切な統合を確実にするために、Vuetifyエクスポートを更新しました。

## 関連するIssue
#17 

## チェックリスト
- [ ] コードが正しく動作することを確認しました
- [ ] テストを追加/更新しました
- [ ] ドキュメントを更新しました

## その他
導入のみで動作確認のコードは反映してない


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- Vuetifyアイコンセットの設定を強化し、デフォルトアイコンをMaterial Design Icons (MDI)に設定しました。

- **改善**
	- アイコン管理の機能を拡張し、より柔軟なアイコン設定を可能にしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->